### PR TITLE
トランポリン判定を追加

### DIFF
--- a/Assets/Materials/Trampoline.mat
+++ b/Assets/Materials/Trampoline.mat
@@ -1,0 +1,80 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Trampoline
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 0.53454286, b: 0, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Materials/Trampoline.mat.meta
+++ b/Assets/Materials/Trampoline.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 46df74cfb86b76b4785493c7570fe647
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SampleStage.unity
+++ b/Assets/Scenes/SampleStage.unity
@@ -135,8 +135,8 @@ GameObject:
   - component: {fileID: 35781636}
   - component: {fileID: 35781635}
   - component: {fileID: 35781639}
-  - component: {fileID: 35781638}
   - component: {fileID: 35781640}
+  - component: {fileID: 35781638}
   m_Layer: 0
   m_Name: player
   m_TagString: Untagged
@@ -2285,8 +2285,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 735144183}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.08, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalPosition: {x: 0, y: -0.45, z: 0}
+  m_LocalScale: {x: 1, y: 0.2, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 241618056}
@@ -2321,6 +2321,7 @@ MonoBehaviour:
   isGroundEnter: 0
   isGroundStay: 0
   isGroundExit: 0
+  bounceForce: 27
 --- !u!1 &800913762
 GameObject:
   m_ObjectHideFlags: 0
@@ -3962,6 +3963,103 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1374590419}
   m_Mesh: {fileID: -364044783463932134, guid: e729e003cc4bd474c83077b789c2edd6, type: 3}
+--- !u!1 &1401005005
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1401005009}
+  - component: {fileID: 1401005008}
+  - component: {fileID: 1401005007}
+  - component: {fileID: 1401005006}
+  m_Layer: 0
+  m_Name: Trampoline
+  m_TagString: Trampoline
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &1401005006
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1401005005}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1401005007
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1401005005}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 46df74cfb86b76b4785493c7570fe647, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1401005008
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1401005005}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1401005009
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1401005005}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 7.87, y: -0.83, z: -1}
+  m_LocalScale: {x: 2, y: 0.2, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1430564987
 GameObject:
   m_ObjectHideFlags: 0
@@ -5132,8 +5230,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1884125538}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.06, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalPosition: {x: 0, y: -0.45, z: 0}
+  m_LocalScale: {x: 1, y: 0.2, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 579887068}
@@ -5168,6 +5266,7 @@ MonoBehaviour:
   isGroundEnter: 0
   isGroundStay: 0
   isGroundExit: 0
+  bounceForce: 27
 --- !u!1 &1985331062
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/IsGroundScript.cs
+++ b/Assets/Scripts/IsGroundScript.cs
@@ -5,11 +5,20 @@ using UnityEngine;
 public class IsGroundScript : MonoBehaviour
 {
     private string groundTag = "Ground";
+    private string trampolineTag = "Trampoline"; // トランポリン用タグ
     public bool isGround = false;
     public bool isGroundEnter, isGroundStay, isGroundExit;
+    public float bounceForce = 15f; // 跳ねる力
 
-    //接地判定を返すメソッド
-    //物理判定の更新毎に呼ぶ必要がある
+    private Rigidbody playerRb;
+
+    private void Start()
+    {
+        // 親オブジェクトの Rigidbody を取得
+        playerRb = GetComponentInParent<Rigidbody>();
+    }
+
+    // 接地判定を返すメソッド
     public bool Ground()
     {
         if (isGroundEnter || isGroundStay)
@@ -29,14 +38,27 @@ public class IsGroundScript : MonoBehaviour
 
     private void OnTriggerEnter(Collider other)
     {
+        // 地面判定
         if (other.tag == groundTag)
         {
             isGroundEnter = true;
+        }
+
+        // トランポリン判定
+        if (other.tag == trampolineTag)
+        {
+            if (playerRb != null)
+            {
+                // 上方向に跳ねる力を加える
+                playerRb.velocity = new Vector3(playerRb.velocity.x, 0, playerRb.velocity.z); // 縦方向の速度をリセット
+                playerRb.AddForce(Vector3.up * bounceForce, ForceMode.Impulse);
+            }
         }
     }
 
     private void OnTriggerStay(Collider other)
     {
+        // 地面に触れている場合の処理
         if (other.tag == groundTag)
         {
             isGroundStay = true;
@@ -45,6 +67,7 @@ public class IsGroundScript : MonoBehaviour
 
     private void OnTriggerExit(Collider other)
     {
+        // 地面から離れた場合の処理
         if (other.tag == groundTag)
         {
             isGroundExit = true;

--- a/Assets/Scripts/Trampoline.meta
+++ b/Assets/Scripts/Trampoline.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e146557792d30004d842bc968fd04068
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Trampoline/TestTrampoline.cs
+++ b/Assets/Scripts/Trampoline/TestTrampoline.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TestTrampoline : MonoBehaviour
+{
+    public bool isTrampoline = false;
+
+    public GameObject Player1;
+    public GameObject Player2;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+
+}

--- a/Assets/Scripts/Trampoline/TestTrampoline.cs.meta
+++ b/Assets/Scripts/Trampoline/TestTrampoline.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 61b46aa3eee5ef349be040b1f656df87
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -8,6 +8,8 @@ TagManager:
   - OretaInteraction
   - MonotaInteraction
   - DeadZone
+  - MonotaIntract
+  - Trampoline
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
トランポリン用オブジェクトをSampleStageシーンに追加（現状はオレンジで色を付けている）
実際はIsGroundscriptの付いたトリガーがTrampolineタグのオブジェクトに触れると親のプレイヤーが跳ねるようになっている。
なのでトランポリンタグを付ければトランポリンが簡単に作れる。
腕トランポリンにする場合、腕が伸びている間だけコライダーをアクティブにするなどの方法で出来るかもしれない、あと腕にトランポリンタグをつける事