### PR TITLE
RedAddTrampoline

### DIFF
--- a/Assets/Scenes/KanataniSP.unity
+++ b/Assets/Scenes/KanataniSP.unity
@@ -1984,6 +1984,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: BULE_PLAYER_FULL
       objectReference: {fileID: 0}
+    - target: {fileID: 2561505656634487589, guid: 4b4d560c8afb01d43925d52c540c0678, type: 3}
+      propertyPath: m_TagString
+      value: Player
+      objectReference: {fileID: 0}
     - target: {fileID: 2764909454355179958, guid: 4b4d560c8afb01d43925d52c540c0678, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 1.6126837
@@ -4804,6 +4808,79 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b21264734cb2e0a4eafc5ae8968079c8, type: 3}
+--- !u!1001 &293805198
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8464179878204726426, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_Name
+      value: Daitikunn1 (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726426, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_TagString
+      value: Ground
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_RootOrder
+      value: 109
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 7.690072
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 10.451
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
 --- !u!1001 &296013653
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9203,19 +9280,19 @@ PrefabInstance:
     - target: {fileID: 1964583271246594229, guid: 490b07944a75cfe47a0562af71f3c1f3, type: 3}
       propertyPath: Player1
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 1144760385}
     - target: {fileID: 1964583271246594229, guid: 490b07944a75cfe47a0562af71f3c1f3, type: 3}
       propertyPath: Player2
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 2093810038}
     - target: {fileID: 1964583271246594229, guid: 490b07944a75cfe47a0562af71f3c1f3, type: 3}
       propertyPath: Player1Start
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 2093810038}
     - target: {fileID: 1964583271246594229, guid: 490b07944a75cfe47a0562af71f3c1f3, type: 3}
       propertyPath: Player2Start
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 1144760385}
     - target: {fileID: 1964583271246594229, guid: 490b07944a75cfe47a0562af71f3c1f3, type: 3}
       propertyPath: respawnDelay
       value: 0.2
@@ -19416,6 +19493,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6819881893468750115, guid: b21264734cb2e0a4eafc5ae8968079c8, type: 3}
   m_PrefabInstance: {fileID: 1390690198}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1144760385 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2561505656634487589, guid: 4b4d560c8afb01d43925d52c540c0678, type: 3}
+  m_PrefabInstance: {fileID: 124841942}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1148444346
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -22296,11 +22378,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Player1Dead: 0
   Player2Dead: 0
-  Player1: {fileID: 0}
-  Player2: {fileID: 0}
+  Player1: {fileID: 1144760385}
+  Player2: {fileID: 2093810038}
   respawnDelay: 2
-  Player1Start: {fileID: 0}
-  Player2Start: {fileID: 0}
+  Player1Start: {fileID: 2093810038}
+  Player2Start: {fileID: 1144760385}
   GameOverSceneName: GameOverScene
 --- !u!65 &1271075528
 BoxCollider:
@@ -24632,6 +24714,24 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8507832078469002614, guid: dc367cf39a9efbe449bbabb7a5bff410, type: 3}
   m_PrefabInstance: {fileID: 825060698}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1460382504 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7194770580955279001, guid: 724e14ba48e4fab4c803ce04cbe05545, type: 3}
+  m_PrefabInstance: {fileID: 1529009513}
+  m_PrefabAsset: {fileID: 0}
+--- !u!65 &1460382505
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1460382504}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.3385099, y: 0.027131118, z: 0.26490635}
+  m_Center: {x: 0.084197946, y: -0.0060925297, z: 0.20015112}
 --- !u!1001 &1463111637
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -25695,6 +25795,10 @@ PrefabInstance:
     - target: {fileID: 8265699384055271207, guid: 724e14ba48e4fab4c803ce04cbe05545, type: 3}
       propertyPath: m_Name
       value: Red_Model_All
+      objectReference: {fileID: 0}
+    - target: {fileID: 8265699384055271207, guid: 724e14ba48e4fab4c803ce04cbe05545, type: 3}
+      propertyPath: m_TagString
+      value: Player
       objectReference: {fileID: 0}
     - target: {fileID: 8790597007245301149, guid: 724e14ba48e4fab4c803ce04cbe05545, type: 3}
       propertyPath: m_RootOrder
@@ -27487,6 +27591,79 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b21264734cb2e0a4eafc5ae8968079c8, type: 3}
+--- !u!1001 &1599688041
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8464179878204726426, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_Name
+      value: Daitikunn1 (16)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726426, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_TagString
+      value: Ground
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_RootOrder
+      value: 110
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 7.690072
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 21.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464179878204726431, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9f8fe44fbb68608418ba00d74550a304, type: 3}
 --- !u!4 &1603934717 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8507832078469002614, guid: dc367cf39a9efbe449bbabb7a5bff410, type: 3}
@@ -34145,6 +34322,21 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 2938488248884423071, guid: 4b4d560c8afb01d43925d52c540c0678, type: 3}
   m_PrefabInstance: {fileID: 124841942}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2071537631
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1144760385}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: defd1eea8ff815040ad7b83cdef60708, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  targetObject: {fileID: 0}
+  trampoline: {fileID: 0}
+  scaleSpeed: 2
 --- !u!1001 &2074329042
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -34542,6 +34734,26 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b21264734cb2e0a4eafc5ae8968079c8, type: 3}
+--- !u!1 &2093810038 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8265699384055271207, guid: 724e14ba48e4fab4c803ce04cbe05545, type: 3}
+  m_PrefabInstance: {fileID: 1529009513}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2093810039
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2093810038}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: defd1eea8ff815040ad7b83cdef60708, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  targetObject: {fileID: 1460382504}
+  trampoline: {fileID: 1460382504}
+  scaleSpeed: 2
 --- !u!4 &2094460065 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8507832078469002614, guid: dc367cf39a9efbe449bbabb7a5bff410, type: 3}


### PR DESCRIPTION
赤い方のキャラクターの髪にトランポリン機能を追加（できたとは思うが実機での確認は不可）
青い方はどの部位にトランポリン付けるのかが不明な為一旦保留
赤青両キャラにPlayerタグを追加